### PR TITLE
Use computed hostname in Next server config

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const port = parseInt(process.env.PORT || '3000', 10);
 console.log(`Starting server in ${dev ? 'development' : 'production'} mode`);
 console.log(`Binding to ${hostname}:${port}`);
 
-const app = next({ dev, hostname: 'localhost', port }); // Next.js should use localhost internally
+const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
 
 app.prepare()


### PR DESCRIPTION
## Summary
- update server.js so Next.js uses the calculated `hostname`

## Testing
- `node tests/wildcard-search.test.js`
- `npm run dev`
- `npm run build` *(fails: unable to fetch fonts)*
- `npm start` *(fails: no production build)*

------
https://chatgpt.com/codex/tasks/task_e_6848c0bb1af48329b3c4a83611726e31